### PR TITLE
Return default paragraph definitions.

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -455,19 +455,7 @@ You can send text to the REPL process from other buffers containing source.
   (setq-local comment-end "")
   (setq-local tab-width swift-indent-offset)
   (setq-local indent-tabs-mode nil)
-  (setq-local indent-line-function 'swift-indent-line)
-
-  (setq-local comment-start-skip
-              (rx (or (and "//" (* "/")) (and "/*" (* "*"))) (* space)))
-
-  (setq-local paragraph-start
-              (rx-to-string `(and (* space)
-                                  (or (regex ,comment-start-skip)
-                                      (and "*" (? "/") (* space)))
-                                  eol)
-                            t))
-
-  (setq-local paragraph-separate paragraph-start))
+  (setq-local indent-line-function 'swift-indent-line))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.swift\\'" . swift-mode))


### PR DESCRIPTION
Defined values for paragraph start and separator doesn't seem to express
common definition of code paragraph. Relying on comments doesn't work in all
situations. Default emacs paragraph definition provides safer common
definitions.

I was really confused about why paragraph movements didn't work for me in valid buffers, I think it will be common situation for users of this mode. I guess it was inherited from `rust-mode`, because I had the same issues with `rust` too. 
