### PR TITLE
Add font-lock for declaration expression with destructuring

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -298,7 +298,9 @@
                               (or ,@swift-mode--val-decl-keywords)
                               eow
                               (+ space)
-                              (group (? "`") bow (+ word) eow (? "`")))
+                              (? "(")
+                              (group (+ (or (+ (? ?`) word (? ?`)) ?, space)))
+                              (? ")"))
                         t)
           (list 1 font-lock-variable-name-face))
 

--- a/test/font-lock-tests.el
+++ b/test/font-lock-tests.el
@@ -126,6 +126,8 @@ test will fail."
 (check-face let-bind/has-variable-face/1 font-lock-variable-name-face "let {{x}} = y")
 (check-face let-bind/has-variable-face/2 font-lock-variable-name-face "let {{foo}} = y")
 (check-face let-bind/has-variable-face/3 font-lock-variable-name-face "let {{x}}: T = y")
+(check-face let-bind/has-variable-face/4 font-lock-variable-name-face "let ({{foo}}, bar) = y")
+(check-face let-bind/has-variable-face/5 font-lock-variable-name-face "let (foo, {{bar}}) = y")
 (check-face let-bind-type-ann/has-type-face/1 font-lock-type-face "let x: {{T}} = y")
 (check-face let-bind-type-ann/has-type-face/2 font-lock-type-face "let x: {{Type}} = y")
 


### PR DESCRIPTION
fixes #2

Not a perfect fix though, it locks `,` too. But still better than not highlighting at all
