### PR TITLE
Highlight interpolation

### DIFF
--- a/test/font-lock-tests.el
+++ b/test/font-lock-tests.el
@@ -186,6 +186,8 @@ test will fail."
 (check-face class/base-type-has-type-face/4 font-lock-type-face "class T<U> : {{Base}}")
 (check-face class/base-type-colon-has-default-face/1 nil "class T {{:}} Base")
 
+(check-face string-interpolation/has-variable-face/1 font-lock-variable-name-face "\"foo {{\\\(bar)}}\"")
+
 (provide 'font-lock-tests)
 
 ;;; font-lock-tests.el ends here


### PR DESCRIPTION
Based on the great [article](http://www.lunaryorn.com/2014/06/16/advanced-syntactic-fontification.html) by @lunaryorn.
As discussed in #16 it highlights whole expression as identifier, so operators are getting highlighted too.

fixes #16
