### PR TITLE
Enable nested flag 'n' for C-style multi-line comments

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -563,8 +563,8 @@ You can send text to the REPL process from other buffers containing source.
     (modify-syntax-entry ?: "_" table)
 
     ;; Comments
-    (modify-syntax-entry ?/  ". 124b" table)
-    (modify-syntax-entry ?*  ". 23"   table)
+    (modify-syntax-entry ?/  ". 124b"  table)
+    (modify-syntax-entry ?*  ". 23n" table)
     (modify-syntax-entry ?\n "> b"    table)
 
     ;; Parenthesis, braces and brackets

--- a/test/font-lock-tests.el
+++ b/test/font-lock-tests.el
@@ -195,6 +195,8 @@ test will fail."
 
 (check-face attributes/has-keyword-face/1 font-lock-keyword-face "{{@IBAction}} func")
 
+(check-face comments/nested-multiline-comments-has-comments-face/1 font-lock-comment-face "/*/* text */{{*/}}")
+
 (provide 'font-lock-tests)
 
 ;;; font-lock-tests.el ends here


### PR DESCRIPTION
fixes #31
