### PR TITLE
Improve font-lock regex for string interpolation

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -405,7 +405,7 @@
     (remove-text-properties start end '(swift-interpolation-match-data))
     (funcall
      (syntax-propertize-rules
-      ((rx (group "\\(" (*? any) ")"))
+      ((rx (group "\\(" (* (any alnum " " "(" ")" "+" "-" "*" "/")) ")"))
        (0 (ignore (swift-syntax-propertize-interpolation)))))
      start end)))
 

--- a/test/font-lock-tests.el
+++ b/test/font-lock-tests.el
@@ -188,6 +188,8 @@ test will fail."
 
 (check-face string-interpolation/has-variable-face/1 font-lock-variable-name-face "\"foo {{\\\(bar)}}\"")
 (check-face string-interpolation/has-variable-face/2 font-lock-variable-name-face "\"{{\\\(bar)}}\"")
+(check-face string-interpolation/has-variable-face/3 font-lock-variable-name-face "\"\\\(bar\(1\){{\)}}\"")
+(check-face string-interpolation/has-variable-face/4 font-lock-variable-name-face "\"\\\(bar\(1\){{ + baz\(2\)\)}}\"")
 (check-face string-interpolation/after-has-string-face/2 font-lock-string-face "\"(foo \\\(bar){{baz}}\")")
 
 (check-face self/has-keyword-face/1 font-lock-keyword-face "{{self}}.foo")


### PR DESCRIPTION
fixes #33 

Not a massive improvement, tested against this cases:

``` swift
"foo \(bar) baz"
"foo \(bar(asdasd)) baz"
("foo \(bar) baz")
("foo \(bar(sadasdsad)) baz")
"foo \(bar() + baz()) baz"
("foo \(bar() + baz()) baz")
```
