### PR TITLE
Don't use implicit semicolon for multi-line dot expressions

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -186,7 +186,8 @@
 
 (defun swift-smie--implicit-semi-p ()
   (save-excursion
-    (not (or (memq (char-before) '(?\{ ?\[ ?\,))
+    (not (or (memq (char-before) '(?\{ ?\[ ?, ?.))
+             (memq (char-after (+(point) 1)) '(?.))
              (looking-back swift-smie--operators-regexp (- (point) 3) t)
              ))))
 

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -774,6 +774,24 @@ Foo.bar(bar?,
         |baz)
 ")
 
+(check-indentation indents-multiline-expressions/4
+                   "
+let json_ary = NSJSONSerialization.
+|JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
+" "
+let json_ary = NSJSONSerialization.
+               |JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
+")
+
+(check-indentation indents-multiline-expressions/5
+                   "
+let json_ary = NSJSONSerialization
+|.JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
+" "
+let json_ary = NSJSONSerialization
+               |.JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
+")
+
 (check-indentation indents-type-annotations/1
                    "
 typealias Foo = Bar<Foo.Baz, Foo>


### PR DESCRIPTION
Added indentation support for this multi-line forms:

``` swift
let json_ary = NSJSONSerialization.
               JSONObjectWithData(data, options: nil, error: &json_err) as NSArray

let json_ary = NSJSONSerialization
               .JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
```

fixes #37 
