### PR TITLE
Make multi-line dot statement offset customisable value

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -53,6 +53,12 @@
   :group 'swift
   :type 'integerp)
 
+(defcustom swift-indent-multiline-dot-offset 2
+  "Defines the indentation offset for for multiline dot statement."
+  :group 'swift
+  :type 'integerp
+  :package-version '(swift-mode "0.3.0"))
+
 (defcustom swift-repl-executable
   "xcrun swift"
   "Path to the Swift CLI."
@@ -265,6 +271,14 @@
     (`(:before . ";")
      (if (smie-rule-parent-p "case" "default")
          (smie-rule-parent swift-indent-offset)))
+
+    ;; Apply swift-indent-multiline-dot-offset only if
+    ;; - dot is followed by newline, or
+    ;; - have at least one whitespace character before dot
+    (`(:before . ".")
+     (if (or (looking-at "[.][\n]")
+             (looking-back "[ \t\n]" 1 t))
+         (smie-rule-parent swift-indent-multiline-dot-offset)))
 
     (`(:before . "if")
      (if (smie-rule-prev-p "else")

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -58,6 +58,7 @@ values of customisable variables."
               ;; Bind customisable vars to default values for tests.
               (swift-indent-offset 4)
               (swift-indent-switch-case-offset 0)
+              (swift-indent-multiline-dot-offset 2)
               ,@var-bindings)
          (with-temp-buffer
            (insert ,before)
@@ -809,6 +810,36 @@ let json_ary = NSJSONSerialization
 let json_ary = NSJSONSerialization
                |.JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
 ")
+
+(check-indentation indents-multiline-expressions-to-user-defined-offset/1
+                   "
+NSNotificationCenter.defaultCenter().
+|postNotificationName(foo, object: nil)
+" "
+NSNotificationCenter.defaultCenter().
+    |postNotificationName(foo, object: nil)
+"
+((swift-indent-multiline-dot-offset 4)))
+
+(check-indentation indents-multiline-expressions-to-user-defined-offset/2
+                   "
+NSNotificationCenter.defaultCenter()
+|.postNotificationName(foo, object: nil)
+" "
+NSNotificationCenter.defaultCenter()
+    |.postNotificationName(foo, object: nil)
+"
+((swift-indent-multiline-dot-offset 4)))
+
+(check-indentation indents-multiline-expressions-to-user-defined-offset/3
+                   "
+let json_ary = NSJSONSerialization
+               |.JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
+" "
+let json_ary = NSJSONSerialization
+                 |.JSONObjectWithData(data, options: nil, error: &json_err) as NSArray
+"
+((swift-indent-multiline-dot-offset 4)))
 
 (check-indentation indents-type-annotations/1
                    "


### PR DESCRIPTION
Introduced new custom indentation offset value for multi-line dot expression: `swift-indent-multiline-dot-offset`. It defaults to `nil` to match default `smie`behaviour.

Fixes #41 
