### PR TITLE
Multiline op statemenets

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -280,6 +280,12 @@
              (looking-back "[ \t\n]" 1 t))
          (smie-rule-parent swift-indent-multiline-statement-offset)))
 
+    ;; Apply swift-indent-multiline-statement-offset if
+    ;; operator is the last symbol on the line
+    (`(:before . "OP")
+     (if (looking-at ".[\n]")
+         (smie-rule-parent swift-indent-multiline-statement-offset)))
+
     (`(:before . "if")
      (if (smie-rule-prev-p "else")
          (if (smie-rule-parent-p "{")

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -850,6 +850,16 @@ let json_ary = NSJSONSerialization
 "
 ((swift-indent-multiline-statement-offset 4)))
 
+(check-indentation indents-multiline-expressions-to-user-defined-offset/4
+                   "
+let options = NSRegularExpressionOptions.CaseInsensitive &
+|NSRegularExpressionOptions.DotMatchesLineSeparators
+" "
+let options = NSRegularExpressionOptions.CaseInsensitive &
+                |NSRegularExpressionOptions.DotMatchesLineSeparators
+"
+((swift-indent-multiline-statement-offset 4)))
+
 (check-indentation indents-type-annotations/1
                    "
 typealias Foo = Bar<Foo.Baz, Foo>


### PR DESCRIPTION
- Improved `dot-exp` `bnf` grammar, fixes #44;
- Added customisable offset for the multi-line statements with hanging operator, as requested in #44;
- Renamed `swift-indent-multiline-dot-offset` to `swift-indent-multiline-statement-offset` to make it more generic.

I hope it's not too late to rename this parameter, I didn't account other multi-line cases initially.
