### PR TITLE
Make all possible operators allowed in string interpolation

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -426,7 +426,7 @@
     (remove-text-properties start end '(swift-interpolation-match-data))
     (funcall
      (syntax-propertize-rules
-      ((rx (group "\\(" (* (any alnum " " "(" ")" "+" "-" "*" "/" "_" ".")) ")"))
+      ((rx (group "\\(" (* (any alnum " ()+-._/*[]!?<>&~!:|^%")) ")"))
        (0 (ignore (swift-syntax-propertize-interpolation)))))
      start end)))
 

--- a/test/font-lock-tests.el
+++ b/test/font-lock-tests.el
@@ -192,6 +192,9 @@ test will fail."
 (check-face string-interpolation/has-variable-face/4 font-lock-variable-name-face "\"\\\(bar\(1\){{ + baz\(2\)\)}}\"")
 (check-face string-interpolation/has-variable-face/5 font-lock-variable-name-face "\"foo {{\\\(bar_baz)}}\"")
 (check-face string-interpolation/has-variable-face/6 font-lock-variable-name-face "\"foo {{\\\(bar.baz)}}\"")
+(check-face string-interpolation/has-variable-face/7 font-lock-variable-name-face "\"foo {{\\\(bar[0])}}\"")
+(check-face string-interpolation/has-variable-face/8 font-lock-variable-name-face "\"foo {{\\\(bar!.baz)}}\"")
+(check-face string-interpolation/has-variable-face/9 font-lock-variable-name-face "\"foo {{\\\(bar?.baz)}}\"")
 (check-face string-interpolation/after-has-string-face/2 font-lock-string-face "\"(foo \\\(bar){{baz}}\")")
 
 (check-face self/has-keyword-face/1 font-lock-keyword-face "{{self}}.foo")


### PR DESCRIPTION
Not sure why I haven't done it earlier...

fixes #49
