### PR TITLE
Treat default clause for case statement as a whole with colon in bnf grammar

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -140,7 +140,7 @@
        (case-exps (guard-exp))
        (cases (case-exps ":" insts)
               (cases "case" cases))
-       (switch-body (cases) (cases "default" insts))
+       (switch-body (cases) (cases "default:" insts))
 
        (for-head (in-exp) (op-exp) (for-head ";" for-head))
 
@@ -269,7 +269,7 @@
      (if (smie-rule-parent-p "switch")
          (smie-rule-parent swift-indent-switch-case-offset)))
     (`(:before . ";")
-     (if (smie-rule-parent-p "case" "default")
+     (if (smie-rule-parent-p "case" "default:")
          (smie-rule-parent swift-indent-offset)))
 
     ;; Apply swift-indent-multiline-statement-offset only if

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -354,13 +354,17 @@ case y:
   "
 {
     switch true {
-|default
+    case y:
+        x
+|default:
     }
 }
 " "
 {
     switch true {
-    |default
+    case y:
+        x
+    |default:
     }
 }
 ")
@@ -369,13 +373,17 @@ case y:
   "
 {
     switch true {
-              |default
+    case y:
+        x
+              |default:
     }
 }
 " "
 {
     switch true {
-    |default
+    case y:
+        x
+    |default:
     }
 }
 ")


### PR DESCRIPTION
This commit removes ambiguity from case statement grammars, it seems default
lexer parses this statement as a whole. Also improved tests for case
statements to actually catch related bug.

fixes #48
