### PR TITLE
Fix 47

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -287,6 +287,12 @@
      (if (looking-at ".[\n]")
          (smie-rule-parent swift-indent-multiline-statement-offset)))
 
+    ;; Indent second line of the multi-line class
+    ;; definitions with swift-indent-offset
+    (`(:before . ",")
+     (if (smie-rule-parent-p "class")
+       swift-indent-offset))
+
     (`(:before . "if")
      (if (smie-rule-prev-p "else")
          (if (smie-rule-parent-p "{")

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -620,6 +620,17 @@ class Foo: Bar {
 }
 ")
 
+(check-indentation indents-class-declaration/5
+                   "
+class Foo: Foo, Bar,
+|Baz {
+}
+" "
+class Foo: Foo, Bar,
+    |Baz {
+}
+")
+
 (check-indentation indents-func-declaration/1
   "
 func Foo(a: String) {


### PR DESCRIPTION
- Improve `smie` lexer rule for function declaration specifiers;
- Improve indentation of the multi-line `class` declaration statement.

fixes #47 
