### PR TITLE
Fix #55: indentation of multiline operator expressions

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -286,7 +286,8 @@
     ;; Apply swift-indent-multiline-statement-offset if
     ;; operator is the last symbol on the line
     (`(:before . "OP")
-     (if (looking-at ".[\n]")
+     (if (and (looking-at ".[\n]")
+              (not (smie-rule-sibling-p)))
          (smie-rule-parent swift-indent-multiline-statement-offset)))
 
     ;; Indent second line of the multi-line class

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -919,6 +919,19 @@ let foo = bar >
           |baz
 ")
 
+(check-indentation indents-multiline-operators-only-once
+                   "
+1 +
+    2 + 5 *
+|3
+" "
+1 +
+    2 + 5 *
+    |3
+"
+)
+
+
 (provide 'indentation-tests)
 
 ;;; indentation-tests.el ends here


### PR DESCRIPTION
Expressions with multiple operators over multiple lines got indented one
offset deeper per line break. An additional smie check for being a
sibling should fix this problem.

This should fix #55 
