### PR TITLE
Updated syntax: a lot of attributes moved to keywords

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -331,11 +331,12 @@
 (defvar swift-mode--contextual-keywords
   '("associativity" "didSet" "get" "infix" "inout" "left" "mutating" "none"
     "nonmutating" "operator" "override" "postfix" "precedence" "prefix" "right"
-    "set" "unowned" "unowned(safe)" "unowned(unsafe)" "weak" "willSet" "convenience"))
+    "set" "unowned" "unowned(safe)" "unowned(unsafe)" "weak" "willSet" "convenience"
+    "required" "dynamic" "final" "lazy" "optional"))
 
 (defvar swift-mode--attribute-keywords
-  '("assignment" "class_protocol" "exported" "final" "lazy" "noreturn"
-    "NSCopying" "NSManaged" "objc" "optional" "required" "auto_closure"
+  '("class_protocol" "exported" "noreturn"
+    "NSCopying" "NSManaged" "objc" "auto_closure"
     "IBAction" "IBDesignable" "IBInspectable" "IBOutlet"))
 
 (defvar swift-mode--keywords


### PR DESCRIPTION
- required, dynamic, final, lazy and optional are now keywords
- the assignment attribute no longer exists

Source:
https://developer.apple.com/library/mac/documentation/swift/conceptual/Swift_Programming_Language/RevisionHistory.html
