### PR TITLE
Fix eval-after-load problems when swift-mode is byte-compiled

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -481,8 +481,8 @@
 ;;; Flycheck
 
 (eval-after-load 'flycheck
-  '(progn
-     (flycheck-def-option-var flycheck-swift-sdk-path nil swift
+  (lambda ()
+    (flycheck-def-option-var flycheck-swift-sdk-path nil swift
        "A path to the targeted SDK"
        :type '(choice (const :tag "Don't link against sdk" nil)
                       (string :tag "Targeted SDK path"))


### PR DESCRIPTION
Fix eval-after-load problems when byte-compiled.

Use a lambda instead of progn inside eval-after-load body. This is the behavior of the `with-eval-after-load` macro introduced in Emacs 24.4. There seems to be a difference in semantics between progn and
lambda when byte-compiled.
