### PR TITLE
Prevent hang when the point is at the bottom of the buffer

### DIFF
--- a/swift-mode-beginning-of-defun.el
+++ b/swift-mode-beginning-of-defun.el
@@ -782,7 +782,9 @@ Otherwise, try to mark the following one."
                 (when (<= (point) start-pos end-pos end)
                   (throw 'swift-mode:found-block
                          (list (cons (point) end) 'containing)))))
-            (when (= end (point))
+            (when (and
+                   (= end (point))
+                   (not (eobp)))
               ;; Got unmatched parens.
               ;; Scans backward.
               (goto-char start-pos)


### PR DESCRIPTION
Fixes #157 

If the point is at the bottom of the buffer and which-function-mode
is enabled, Emacs freezes. The reason is that the code enters the
"unmatched parens" part of the logic and gets stuck navigating blocks
forward and backward without ever matching a block correctly.

This can be fixed if we check for the end of buffer case explicitly
and return a whole buffer as a block. This makes a point "in between
functions" return the same function information as a point at the end
of the buffer. Graphically:

```
protocol P { func f() }
extension P { func g() { f() } }
struct X<T> : P {
    func f() { print("unconstrained") }
}
<--- Point here (which-function-mode returns "P")
struct X<T> : where T : BinaryInteger {
    func f() { print("constrained")
}
<--- Point here (which-function-mode returns "P")
```