### PR TITLE
Support full-indent for switch cases

### DIFF
--- a/swift-mode-indent.el
+++ b/swift-mode-indent.el
@@ -689,7 +689,8 @@ declaration and its offset is `swift-mode:basic-offset'."
       (goto-char (swift-mode:token:start previous-token))
       (swift-mode:find-parent-and-align-with-next
        swift-mode:statement-parent-tokens
-       (- swift-mode:basic-offset swift-mode:switch-case-offset)))
+       (let ((relative-case-offset (- swift-mode:basic-offset swift-mode:switch-case-offset)))
+         (if (<= relative-case-offset 0) swift-mode:basic-offset relative-case-offset))))
 
      ;; Before ; on the current line
      ((and next-is-on-current-line (eq next-type '\;))

--- a/test/swift-files/indent/statements.swift
+++ b/test/swift-files/indent/statements.swift
@@ -923,6 +923,22 @@ switch foo {
 
 // swift-mode:test:eval (setq-local swift-mode:switch-case-offset 0)
 
+// swift-mode:test:eval (setq-local swift-mode:switch-case-offset 4)
+
+switch foo {
+    case foo:
+        foo()
+        if let x = y {
+            bar()
+        }
+        foo()
+    default:
+        foo()
+        foo()
+}
+
+// swift-mode:test:eval (setq-local swift-mode:switch-case-offset 0)
+
 
 
 // Labeled statements


### PR DESCRIPTION
When `swift-mode:switch-case-offset` is set equal to the basic offset,
lines following a `case` inside a `switch` should still be indented.

Change the offset calculation to fall back to `swift-mode:basic-offset`
if the difference between the offsets is 0 (or less).

Resolves #166