### PR TITLE
Use isAvailable when reading simctl device JSON

### DIFF
--- a/swift-mode-repl.el
+++ b/swift-mode-repl.el
@@ -431,8 +431,7 @@ or its ancestors."
          (flattened (apply 'seq-concatenate 'list (seq-map 'cdr devices)))
          (available-devices
           (seq-filter
-           (lambda (device)
-             (string-equal (cdr (assoc 'availability device)) "(available)"))
+           (lambda (device) (cdr (assoc 'isAvailable device)))
            flattened)))
     available-devices))
 


### PR DESCRIPTION
`swift-mode:debug-ios-app` was failing because no simulator could
be configured; the output of `simctl` was not as expected.

The `availability` field of the `device` object had been deprecated
and was removed as of Xcode 11 (see
https://developer.apple.com/documentation/xcode-release-notes/xcode-11-release-notes
heading "Resolved Issues") in favor of a boolean `isAvailable`.