### PR TITLE
Fix inner scope guard indent

### DIFF
--- a/swift-mode-indent.el
+++ b/swift-mode-indent.el
@@ -912,7 +912,7 @@ OFFSET is extra offset if given."
   (let ((parent (swift-mode:backward-sexps-until
                  (append
                   (remove 'implicit-\; swift-mode:statement-parent-tokens)
-                  '("if")))))
+                  '("if" "guard")))))
     (if (equal (swift-mode:token:text parent) "if")
         (cond
          ;; Found "if" at the beginning of a line.  Align with it.

--- a/test/swift-files/indent/statements.swift
+++ b/test/swift-files/indent/statements.swift
@@ -715,6 +715,14 @@ guard
 else {
 }
 
+// Inner scope guard
+
+func main() {
+    guard foo else {
+        bar()
+    }
+}
+
 // Switch statement
 
 switch foo


### PR DESCRIPTION
Commit [25e41ed](https://github.com/swift-emacs/swift-mode/commit/25e41ed7d405ea566a45fef7cdb673b86ae01701) broken indentation of guard statements when nested within an inner scope. It's been bugging me for a while 😄 

This PR fixes the indentation.

Before:

```
func main() {
    guard foo else {
    // wrong indentation
    }
}
```

After:

```
func main() {
    guard foo else {
        // correct indentation
    }
}
```
