### PR TITLE
Update Swift indentation offset defaults

### DIFF
--- a/swift-mode-indent.el
+++ b/swift-mode-indent.el
@@ -39,13 +39,13 @@
   :group 'swift
   :safe #'integerp)
 
-(defcustom swift-mode:parenthesized-expression-offset 2
+(defcustom swift-mode:parenthesized-expression-offset 4
   "Amount of indentation inside parentheses and square brackets."
   :type 'integer
   :group 'swift
   :safe #'integerp)
 
-(defcustom swift-mode:multiline-statement-offset 2
+(defcustom swift-mode:multiline-statement-offset 4
   "Amount of indentation for continuations of expressions."
   :type 'integer
   :group 'swift


### PR DESCRIPTION
As per I discussed in #202, the default values for following seem to make sense to be 4 now (or at least aligned with `swift-mode:basic-offset` with any value).

- `swift-mode:multiline-statement-offset`
- `swift-mode:parenthesized-expression-offset`